### PR TITLE
Pyotato

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,5 @@
 | 2023-06-02 | [듣보잡](https://www.acmicpc.net/problem/1764)                      |              | ✅           | ✅     | ✅     |
 | 2023-06-03 | [토마토](https://www.acmicpc.net/problem/7576)                      | ✅           | ✅           | ✅     | ✅     |
 | 2023-06-04 | [이중 우선순위 큐](https://www.acmicpc.net/problem/7662)            | ✅           |              |        | ✅     |
-| 2023-06-05 | [쉬운 최단거리](https://www.acmicpc.net/problem/14940)              |              |              |        | ✅     |
+| 2023-06-05 | [쉬운 최단거리](https://www.acmicpc.net/problem/14940)              | ✅           |              | ✅     | ✅     |
+| 2023-06-06 | [구간합 구하기 ](https://www.acmicpc.net/problem/14940)             | ✅           |              | ✅     | ✅     |

--- a/표혜민/README.md
+++ b/표혜민/README.md
@@ -39,3 +39,4 @@
    5. [[2023.06.03][7576][bfs] DAY26 : 토마토](https://www.acmicpc.net/source/61598460)
    6. [[2023.06.04][7662][] DAY27 : 이중 우선순위 큐](https://www.acmicpc.net/source/)
    7. [[2023.06.05][14940][bfs] DAY28 : 쉬운 최단거리](https://www.acmicpc.net/source/61712323)
+   8. [[2023.06.06][11659][prefix sum] DAY29 : 구간 합 구하기](https://www.acmicpc.net/source/61757027)

--- a/표혜민/class03/WEEK05/14940/0.py
+++ b/표혜민/class03/WEEK05/14940/0.py
@@ -1,0 +1,15 @@
+from sys import stdin
+#1 ≤ N ≤ 100,000,1 ≤ M ≤ 100,000,1 ≤ i ≤ j ≤ N
+N, M = map(int, stdin.readline().strip().split())
+nums = list(map(int, stdin.readline().strip().split()))
+tests =[list(map(int, stdin.readline().strip().split())) for i in range(M)]
+dp =[0 for _ in range(N+1)]
+added =0
+
+for i in range(N):
+    added+=nums[i]
+    dp[i+1]=added
+
+for t in tests:
+    s,e = t
+    print(dp[e]-dp[s-1])


### PR DESCRIPTION
처음에는 아래와 같이 테스트케이스마다 합을 구해주는 방식으로 풀려고 했지만 
시간 초과가 났습니다.
```python
from sys import stdin
#1 ≤ N ≤ 100,000,1 ≤ M ≤ 100,000,1 ≤ i ≤ j ≤ N
N, M = map(int, stdin.readline().strip().split())
nums = list(map(int, stdin.readline().strip().split()))
for _ in range(M):
    s,e = map(int, stdin.readline().strip().split())
    items = nums[s-1:e]
    print(sum(items))
``` 
대신 dp문제 풀듯이 누적합을 저장해서 해당 구간의 값을 구하는 방식으로 풀이했습니다.