### PR TITLE
1167 트리 지름

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,45 +22,47 @@
 - ❌ : 미제출
 - `20X.XX.XX`: 추후 제출일
 
-| 날짜       | 문제                                                                | 강원영       | 박주영       | 장재균 | 표혜민       |
-| ---------- | ------------------------------------------------------------------- | ------------ | ------------ | ------ | ------------ |
-| 2023-05-15 | [체스판 다시 칠하기](https://www.acmicpc.net/problem/1018)          | ✅           |              |        | ✅           |
-| 2023-05-16 | [큐](https://www.acmicpc.net/problem/10845)                         | ✅           |              |        | ✅           |
-| 2023-05-17 | [덱](https://www.acmicpc.net/problem/10866)                         | ✅           | ✅           | ✅     | ✅           |
-| 2023-05-18 | [숫자 카드 2](https://www.acmicpc.net/problem/10816)                | ✅           | ✅           | ✅     | ✅           |
-| 2023-05-19 | [최대공약수와 최소공배수](https://www.acmicpc.net/problem/2609)     | ✅           | ✅           | ✅     | ✅           |
-| 2023-05-20 | [블랙잭](https://www.acmicpc.net/problem/2798)                      | ✅           | ✅           | ✅     | ✅           |
-| 2023-05-21 | [설탕배달](https://www.acmicpc.net/problem/2839)                    | ✅           | ✅           | ✅     | ✅           |
-| 2023-05-22 | [이항계수](https://www.acmicpc.net/problem/11050)                   | ❌           | ✅           | ✅     | ✅           |
-| 2023-05-23 | [2xn 타일링](https://www.acmicpc.net/problem/11726)                 | ✅           | ✅           | ✅     | ✅           |
-| 2023-05-24 | [ATM](https://www.acmicpc.net/problem/11399)                        | ✅           | ✅           | ✅     | ✅           |
-| 2023-05-25 | [1로 만들기](https://www.acmicpc.net/problem/1463)                  | `2023.05.30` | ✅           | ✅     | ✅           |
-| 2023-05-26 | [좌표 압축](https://www.acmicpc.net/problem/18870)                  | ✅           | `2023.06.02` | ✅     | ✅           |
-| 2023-05-27 | [숨바꼭질](https://www.acmicpc.net/problem/1697)                    | ❌           | ✅           | ✅     | ✅           |
-| 2023-05-28 | [나는야 포켓몬 마스터 이다솜](https://www.acmicpc.net/problem/1620) | ✅           | ✅           | ✅     | ✅           |
-| 2023-05-29 | [집합](https://www.acmicpc.net/problem/11723)                       | ✅           | ✅           | ✅     | ✅           |
-| 2023-05-30 | [유기농 배추](https://www.acmicpc.net/problem/1012)                 | ✅           | ❌           | ✅     | ✅           |
-| 2023-05-30 | [회전하는 큐](https://www.acmicpc.net/problem/1021)                 |              | ❌           | ✅     | `2023.05.31` |
-| 2023-05-31 | [피보나치 함수](https://www.acmicpc.net/problem/1003)               |              | ✅           | ✅     | ✅           |
-| 2023-06-01 | [패션왕 신해빈](https://www.acmicpc.net/problem/9375)               |              | ✅           | ✅     | ✅           |
-| 2023-06-02 | [듣보잡](https://www.acmicpc.net/problem/1764)                      |              | ✅           | ✅     | ✅           |
-| 2023-06-03 | [토마토](https://www.acmicpc.net/problem/7576)                      | ✅           | ✅           | ✅     | ✅           |
-| 2023-06-04 | [이중 우선순위 큐](https://www.acmicpc.net/problem/7662)            | ✅           | ✅           |        | ✅           |
-| 2023-06-05 | [쉬운 최단거리](https://www.acmicpc.net/problem/14940)              | ✅           | `2023.06.06` | ✅     | ✅           |
-| 2023-06-06 | [구간합 구하기 4](https://www.acmicpc.net/problem/11659)            | ✅           | ✅           | ✅     | ✅           |
-| 2023-06-07 | [최소힙 ](https://www.acmicpc.net/problem/1927)                     | ✅           | ✅           | ✅     | ✅           |
-| 2023-06-08 | [RGB거리](https://www.acmicpc.net/problem/1149)                     | ✅           | ✅           | ✅     | ✅           |
-| 2023-06-09 | [후위표기식](https://www.acmicpc.net/problem/1918)                  | ✅           | ✅           | ✅     | ✅           |
-| 2023-06-10 | [정수삼각형](https://www.acmicpc.net/problem/1932)                  | ✅           | ✅           | ✅     | ✅           |
-| 2023-06-11 | [스티커](https://www.acmicpc.net/problem/1932)                      | ✅           | ✅           | ✅     | ✅           |
-| 2023-06-12 | [구간 합 구하기 5](https://www.acmicpc.net/problem/11660)           |              |   ✅           |   ✅    |     ✅  |
-| 2023-06-13 | [N과 M (2)](https://www.acmicpc.net/problem/15650)                  |              |  ✅            |        | ✅           |
-| 2023-06-14 | [숨바꼭질 3](https://www.acmicpc.net/problem/13549)                 |              |    ❌          | ✅     |    ✅          |
-| 2023-06-15 | [플로이드](https://www.acmicpc.net/problem/11404)                   |              |     ❌         | ✅     |        `플로이드 러셀 공부 후 풀이 예정`       |
-| 2023-06-16 | [곱셈](https://www.acmicpc.net/problem/1629)                        |              |   ✅           |        | ✅           |
-| 2023-06-17 | [벽 부수고 이동하기](https://www.acmicpc.net/problem/2206)          |              |    ✅          |                  | ✅  |
-| 2023-06-18 | [N과 M (5)](https://www.acmicpc.net/problem/15654)                  | ✅           | ✅           | ✅           | ✅  |
-| 2023-06-19 | [N과 M (9)](https://www.acmicpc.net/problem/15654)                  |              |              |                   | ✅  |
-| 2023-06-20 | [최단경로](https://www.acmicpc.net/problem/1753)                    | ✅           |              |                   | ✅  |
-| 2023-06-22 | [웜홀](https://www.acmicpc.net/problem/1865)                        | ✅           | ✅           |        | `벨만포드 공부 후 풀이 예정` |
-| 2023-06-23 | [파티](https://www.acmicpc.net/problem/1238)                        |              |              |       | ✅                           |
+| 날짜       | 문제                                                                | 강원영       | 박주영       | 장재균 | 표혜민                            |
+| ---------- | ------------------------------------------------------------------- | ------------ | ------------ | ------ | --------------------------------- |
+| 2023-05-15 | [체스판 다시 칠하기](https://www.acmicpc.net/problem/1018)          | ✅           |              |        | ✅                                |
+| 2023-05-16 | [큐](https://www.acmicpc.net/problem/10845)                         | ✅           |              |        | ✅                                |
+| 2023-05-17 | [덱](https://www.acmicpc.net/problem/10866)                         | ✅           | ✅           | ✅     | ✅                                |
+| 2023-05-18 | [숫자 카드 2](https://www.acmicpc.net/problem/10816)                | ✅           | ✅           | ✅     | ✅                                |
+| 2023-05-19 | [최대공약수와 최소공배수](https://www.acmicpc.net/problem/2609)     | ✅           | ✅           | ✅     | ✅                                |
+| 2023-05-20 | [블랙잭](https://www.acmicpc.net/problem/2798)                      | ✅           | ✅           | ✅     | ✅                                |
+| 2023-05-21 | [설탕배달](https://www.acmicpc.net/problem/2839)                    | ✅           | ✅           | ✅     | ✅                                |
+| 2023-05-22 | [이항계수](https://www.acmicpc.net/problem/11050)                   | ❌           | ✅           | ✅     | ✅                                |
+| 2023-05-23 | [2xn 타일링](https://www.acmicpc.net/problem/11726)                 | ✅           | ✅           | ✅     | ✅                                |
+| 2023-05-24 | [ATM](https://www.acmicpc.net/problem/11399)                        | ✅           | ✅           | ✅     | ✅                                |
+| 2023-05-25 | [1로 만들기](https://www.acmicpc.net/problem/1463)                  | `2023.05.30` | ✅           | ✅     | ✅                                |
+| 2023-05-26 | [좌표 압축](https://www.acmicpc.net/problem/18870)                  | ✅           | `2023.06.02` | ✅     | ✅                                |
+| 2023-05-27 | [숨바꼭질](https://www.acmicpc.net/problem/1697)                    | ❌           | ✅           | ✅     | ✅                                |
+| 2023-05-28 | [나는야 포켓몬 마스터 이다솜](https://www.acmicpc.net/problem/1620) | ✅           | ✅           | ✅     | ✅                                |
+| 2023-05-29 | [집합](https://www.acmicpc.net/problem/11723)                       | ✅           | ✅           | ✅     | ✅                                |
+| 2023-05-30 | [유기농 배추](https://www.acmicpc.net/problem/1012)                 | ✅           | ❌           | ✅     | ✅                                |
+| 2023-05-30 | [회전하는 큐](https://www.acmicpc.net/problem/1021)                 |              | ❌           | ✅     | `2023.05.31`                      |
+| 2023-05-31 | [피보나치 함수](https://www.acmicpc.net/problem/1003)               |              | ✅           | ✅     | ✅                                |
+| 2023-06-01 | [패션왕 신해빈](https://www.acmicpc.net/problem/9375)               |              | ✅           | ✅     | ✅                                |
+| 2023-06-02 | [듣보잡](https://www.acmicpc.net/problem/1764)                      |              | ✅           | ✅     | ✅                                |
+| 2023-06-03 | [토마토](https://www.acmicpc.net/problem/7576)                      | ✅           | ✅           | ✅     | ✅                                |
+| 2023-06-04 | [이중 우선순위 큐](https://www.acmicpc.net/problem/7662)            | ✅           | ✅           |        | ✅                                |
+| 2023-06-05 | [쉬운 최단거리](https://www.acmicpc.net/problem/14940)              | ✅           | `2023.06.06` | ✅     | ✅                                |
+| 2023-06-06 | [구간합 구하기 4](https://www.acmicpc.net/problem/11659)            | ✅           | ✅           | ✅     | ✅                                |
+| 2023-06-07 | [최소힙 ](https://www.acmicpc.net/problem/1927)                     | ✅           | ✅           | ✅     | ✅                                |
+| 2023-06-08 | [RGB거리](https://www.acmicpc.net/problem/1149)                     | ✅           | ✅           | ✅     | ✅                                |
+| 2023-06-09 | [후위표기식](https://www.acmicpc.net/problem/1918)                  | ✅           | ✅           | ✅     | ✅                                |
+| 2023-06-10 | [정수삼각형](https://www.acmicpc.net/problem/1932)                  | ✅           | ✅           | ✅     | ✅                                |
+| 2023-06-11 | [스티커](https://www.acmicpc.net/problem/1932)                      | ✅           | ✅           | ✅     | ✅                                |
+| 2023-06-12 | [구간 합 구하기 5](https://www.acmicpc.net/problem/11660)           |              | ✅           | ✅     | ✅                                |
+| 2023-06-13 | [N과 M (2)](https://www.acmicpc.net/problem/15650)                  |              | ✅           |        | ✅                                |
+| 2023-06-14 | [숨바꼭질 3](https://www.acmicpc.net/problem/13549)                 |              | ❌           | ✅     | ✅                                |
+| 2023-06-15 | [플로이드](https://www.acmicpc.net/problem/11404)                   |              | ❌           | ✅     | `플로이드 러셀 공부 후 풀이 예정` |
+| 2023-06-16 | [곱셈](https://www.acmicpc.net/problem/1629)                        |              | ✅           |        | ✅                                |
+| 2023-06-17 | [벽 부수고 이동하기](https://www.acmicpc.net/problem/2206)          |              | ✅           |        | ✅                                |
+| 2023-06-18 | [N과 M (5)](https://www.acmicpc.net/problem/15654)                  | ✅           | ✅           | ✅     | ✅                                |
+| 2023-06-19 | [N과 M (9)](https://www.acmicpc.net/problem/15654)                  |              |              |        | ✅                                |
+| 2023-06-20 | [최단경로](https://www.acmicpc.net/problem/1753)                    | ✅           |              |        | ✅                                |
+| 2023-06-22 | [웜홀](https://www.acmicpc.net/problem/1865)                        | ✅           | ✅           |        | `벨만포드 공부 후 풀이 예정`      |
+| 2023-06-23 | [파티](https://www.acmicpc.net/problem/1238)                        |              | ✅           | ✅     | ✅                                |
+| 2023-06-24 | [피보나치 수 6](https://www.acmicpc.net/problem/11444)              |              | ✅           | ✅     | ✅                                |
+| 2023-06-25 | [트리의 지름](https://www.acmicpc.net/problem/1167)                 |              |              |        | ✅                                |

--- a/표혜민/README.md
+++ b/표혜민/README.md
@@ -64,4 +64,5 @@
    5. [[2023.06.23][1238][dijkstra] DAY44 : 파티](https://www.acmicpc.net/source/62422606)
    6. [[2023.06.24][11444][divide and conquer using power of N] DAY45 : 피보나치 수 6](https://www.acmicpc.net/source/62457856)
    7. [[2023.06.24][1504][dijkstra] DAY45 : 특정한 최단 경로](https://www.acmicpc.net/source/62460477)
-   8. [[2023.06.24][1238][dijkstra] DAY44 : 파티](https://www.acmicpc.net/source/62460959)
+   8. [[2023.06.24][1238][dijkstra] DAY45 : 파티](https://www.acmicpc.net/source/62460959)
+   9. [[2023.06.25][1167][dfs][tree] DAY46 : 트리의 지름](https://www.acmicpc.net/source/62497120)

--- a/표혜민/class04/WEEK07/1167/0.py
+++ b/표혜민/class04/WEEK07/1167/0.py
@@ -1,0 +1,29 @@
+#두 점 사이의 거리 중 가장 긴 것
+from sys import stdin
+from collections import deque
+V = int(stdin.readline().strip()) #2 ≤ V ≤ 100,000
+tree = [[] for _ in range(V + 1)]
+for _ in range(V):
+    t = list(map(int, stdin.readline().strip().split()))
+    for e in range(1, len(t) - 2, 2):
+        tree[t[0]].append((t[e + 1],t[e])) # w,e
+
+def bfs(s):
+    visited = [-1]*(V+1)
+    dq = deque()
+    dq.append(s)
+    visited[s]=0
+    ans = [0,0]
+    while dq:
+        b = dq.popleft()
+        for w,e in tree[b]:
+            if visited[e] == -1:
+                visited[e] = visited[b]+w
+                dq.append(e)
+                if ans[0] < visited[e]:
+                    ans = visited[e],e
+    return ans
+
+d, node = bfs(1) #노드 1부터 시작
+d, node = bfs(node) 
+print(d)

--- a/표혜민/class04/WEEK07/1504/0.py
+++ b/표혜민/class04/WEEK07/1504/0.py
@@ -1,0 +1,39 @@
+# a와 b 사이의 양방향 길,
+# 다시 갈 수는 있지만 꼭 건너야하는 지점은 거치고
+# 최소 경로로 가야함
+from sys import stdin,maxsize
+from heapq import heappop, heappush
+N, E = map(int, stdin.readline().strip().split())
+inf =maxsize
+g = [[] for _ in range(N+1)]
+for _ in range(E):
+    a,b,c = map(int, stdin.readline().strip().split())
+    g[a].append((c,b))
+    g[b].append((c,a))
+v1,v2 = map(int, stdin.readline().strip().split())
+
+def dijkstra(n):
+    heap = []
+    dp =[inf]*(N+1)
+    dp[n]=0
+    heappush(heap,(0,n))
+    while heap:
+        cst, nxt = heappop(heap)
+        if dp[nxt]<cst:
+            continue
+        for acc_c , idx in g[nxt]:
+            nxt_c = acc_c+cst
+            if nxt_c < dp[idx]:
+                dp[idx] = nxt_c
+                heappush(heap,(nxt_c,idx))
+    return dp
+
+s1 = dijkstra(1) #start 1
+sv1 = dijkstra(v1) #start v1
+sv2 = dijkstra(v2) #start v2
+
+v1_route = s1[v1]+sv1[v2]+sv2[N]
+v2_route = s1[v2]+sv1[N]+sv2[v1]
+
+ans = min(v1_route,v2_route)
+print(ans if ans<inf else -1) 


### PR DESCRIPTION
트리 순회 문제입니다. 

그래프와 트리의 가장 큰 차이는 그래프와 달리 트리는 `부모와 자식 노드라는 상하관계가 있는 점` 같습니다.  
👍 🤗다른 트리와 그래프의 차이점들도 추가해주시면 유익할 거 같습니다. 

![image](https://github.com/onezerokang/algorithm-study-jungle/assets/102423086/fa6a4c58-80ed-4f60-a9dd-a70c009e97de)

그래프로 그렸을 때는 이를 느끼기는 어렵지만

트리형태로 보면 그림과 같이 1이 부모, 3 가 그의 자식, 4가 그의 자식 노드, 그리고 마지막 level에는 2,5가 자식 노드입니다. 

해당 문제는 트리의 지름, 즉, 부모인 1에서 마지막 자식들 level까지 도달하면서 가장 큰 간선들의 합을 구해주면 됩니다. 

풀이에서 아래와 같이 bfs를 두번 돌아야하는데, 이는 명시적으로 1번 노드가 시작이라고 지정되지 않기 때문에 일단 첫번째 노드를 기준으로 가장 먼 노드를 찾고

해당 노드에서 다시 bfs를 돌아서 임의의 두 점 사이의 최장거리인 트리의 지름을 구하는 것입니다.

```python 
d, node = bfs(1) #노드 1부터 시작
d, node = bfs(node) 
print(d)
```
[트리 지름 증명 참고 좋은 자료](https://blog.myungwoo.kr/112)
