### PR TITLE
1167. 트리의 지름/트리,dfs | 1967. 트리의 지름/그래프 탐색, dfs

### DIFF
--- a/박주영/class04/1167.py
+++ b/박주영/class04/1167.py
@@ -1,0 +1,51 @@
+# 트리
+
+# 트리의 지름을 구하시오
+
+import sys
+input = sys.stdin.readline
+sys.setrecursionlimit(10**9)    
+
+V = int(input().rstrip())
+graph = [[] for _ in range(V+1)]
+
+for _ in range(1, V+1):
+    line = list(map(int, input().split()))
+    idx = 0
+    for j in range(len(line)-1):
+        if j == 0:
+            idx = line[j]
+        elif j % 2 == 1:
+            a = line[j]
+            b = line[j+1]
+            graph[idx].append([a, b])
+        elif j % 2 == 0:
+            continue
+
+def dfs(x, weight):
+    for i in graph[x]:
+        a, b = i
+        if distance[a] == -1:
+            distance[a] = weight + b
+            dfs(a, weight + b)
+    return
+
+# 첫번재 시행, 첫 요소부터 가장 먼 점 1찾는다
+
+distance = [-1] * (V+1)
+distance[1] = 0
+
+dfs(1, 0)
+
+start = distance.index(max(distance))
+
+# 두번째 시행, 점 1부터 가장 먼 점 2를 찾는다, 이게 지름
+
+distance = [-1] * (V+1)
+distance[start] = 0
+
+dfs(start, 0)
+
+#========================
+
+print(max(distance))

--- a/박주영/class04/1967.py
+++ b/박주영/class04/1967.py
@@ -1,0 +1,36 @@
+# 트리의 지름
+
+# 트리의 지름을 구하는 다른 문제이다.
+# 임의 점에서 가장 먼 점 , 거기서 먼 점을 구한다.
+# dfs와 bfs로 풀 수 있으나 복습이 필요한 dfs로 풀어보자.
+
+import sys
+input = sys.stdin.readline
+sys.setrecursionlimit(10**9)
+
+def dfs(Start, Graph, Distance):
+    for i in Graph[Start]:
+        next_node, weight = i
+        if (Distance[next_node] == -1):
+            Distance[next_node] = weight + Distance[Start]
+            dfs(next_node, Graph, Distance)
+
+n = int(input().rstrip())
+graph = [[]*(n+1) for _ in range(n+1)]
+
+for i in range(n-1):
+    parent, child, weight = map(int, input().split())
+    graph[parent].append([child, weight])
+    graph[child].append([parent, weight])
+
+distance_rand = [-1] * (n+1)
+distance_rand[1] = 0
+dfs(1, graph, distance_rand)
+point1 = distance_rand.index(max(distance_rand))
+
+distance_radius = [-1] * (n+1)
+distance_radius[point1] = 0
+dfs(point1, graph, distance_radius)
+ans = max(distance_radius)
+
+print(ans)


### PR DESCRIPTION
답을 참고했는데도 틀려서 수정하는데 시간이 걸렸네요
1. 예시에서는 입력에서, 출발하는 노드를 오름차순으로 받았지만 데이터셋에서는 순차적으로 입력받지 않네요.
2. dfs 복습
3. 트리의 특성: 트리에서 임의의 노드에서 최대 거리에 있는 노드는 반드시 트리 지름의 양 끝 점 중 하나이다.

이 문제는 트리의 특성을 알지 못하면 풀기 힘든 문제였습니다.
이 외에도 구현은 bfs로 할 수 있는 것 같습니다.